### PR TITLE
fix: fn is not a function

### DIFF
--- a/serve.js
+++ b/serve.js
@@ -5,7 +5,7 @@ const http = require('http');
 const port = 8080;
 
 module.exports = function(fn) {
-  const server = http.createServer( handler(fn) );
+  const server = http.createServer( handler(fn.adapt) );
   server.listen(port, (err)=>{
     console.log( "server listening on " + port);
   });


### PR DESCRIPTION
This commit fix the previous error:

```
server listening on 8080
/usr/libexec/s2i/ocf-nodejs-adapter/handler.js:6
    fn(ctx);
    ^

TypeError: fn is not a function
    at Server.<anonymous> (/usr/libexec/s2i/ocf-nodejs-adapter/handler.js:6:5)
    at Server.emit (events.js:182:13)
    at parserOnIncoming (_http_server.js:652:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:109:17)
```

And now we able to see the future/next error:

```
server listening on 8080
loading: [object Object]
internal/modules/cjs/loader.js:583
    throw err;
    ^

Error: Cannot find module '/opt/app-root/src/[object Object]'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at module.exports (/opt/app-root/src/load.js:3:10)
    at adapt (/opt/app-root/src/index.js:5:14)
    at Server.<anonymous> (/usr/libexec/s2i/ocf-nodejs-adapter/handler.js:6:5)
    at Server.emit (events.js:182:13)
    at parserOnIncoming (_http_server.js:652:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:109:17)
```